### PR TITLE
adding alert so user cannot select multiple pin location types

### DIFF
--- a/screens/EditPinScreen.js
+++ b/screens/EditPinScreen.js
@@ -196,6 +196,20 @@ export default class EditPinScreen extends PureComponent {
       Alert.alert('All * marked inputs are required');
       return;
     }
+    //require the user to select only one pin location type
+    selected = 0;
+
+    let selectedPins = this.state.pinType.map(pin => {
+      if (pin.isSelected === true) {
+        selected += 1;
+      }
+      return selectedPins;
+    });
+
+    if (selected > 1) {
+      Alert.alert('Only one pin location type can be selected');
+      return;
+    }
     this.props.setPinByRegion(this.state.regionId, {
       ...payload
     });


### PR DESCRIPTION
I don't see an easy way to not allow the user to physically select multiple types, given that the label component is designed specifically for multiple choices. I can look into this further, but for now given the code freeze deadline, I'm adding an alert requiring the user to only select one pin location type when creating a new pin as a workaround solution. 