### PR TITLE
Allow admin to reset user password through the profile screen

### DIFF
--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -8,16 +8,26 @@ import StyledInput from '../components/StyledInput';
 import { StyledText } from '../components/StyledText';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { delayExec } from '../utils/utils';
+
 export default class ProfileScreen extends React.PureComponent {
   state = {
+    email: '',
     newPassword: '',
     rePassword: ''
   };
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.auth && nextProps.auth.passwordChangeStatus) {
-      if (nextProps.auth.passwordChangeStatus.length > 0)
+      if (
+        nextProps.auth.passwordChangeStatus.length > 0 &&
+        this.props.auth.user.Email__c === 'masteraccount@hands.org'
+      ) {
+        Alert.alert(
+          'Password changed successfully! Please notify the user of their new password.'
+        );
+      } else if (nextProps.auth.passwordChangeStatus.length > 0) {
         Alert.alert(nextProps.auth.passwordChangeStatus);
+      }
     }
   }
 
@@ -29,17 +39,26 @@ export default class ProfileScreen extends React.PureComponent {
 
   handlePaswordChange = async () => {
     this.styledButton2.load();
-    const { newPassword, rePassword } = this.state;
+    const { email, newPassword, rePassword } = this.state;
     if (!newPassword.length > 0 || !rePassword.length > 0) {
       Alert.alert('Required (*) fields cannot be blank.');
     } else if (newPassword !== rePassword) {
       Alert.alert("Passwords don't match.");
     } else {
-      await this.props.changePassword({
-        email: this.props.auth.user.Email__c,
-        newPassword
-      });
+      if (this.props.auth.user.Email__c === 'masteraccount@hands.org') {
+        await this.props.changePassword({
+          email,
+          newPassword
+        });
+      } else {
+        await this.props.changePassword({
+          email: this.props.auth.user.Email__c,
+          newPassword
+        });
+      }
+
       this.setState({
+        email: '',
         newPassword: '',
         rePassword: ''
       });
@@ -50,135 +69,280 @@ export default class ProfileScreen extends React.PureComponent {
   render() {
     if (!this.props.auth.user) return null;
     const { Name__c, Email__c } = this.props.auth.user;
-    return (
-      <KeyboardAwareScrollView
-        style={{
-          backgroundColor: Colors.defaultColor.PAGE_BACKGROUND,
-          flex: 1
-        }}
-        resetScrollToCoords={{ x: 0, y: 0 }}
-        showsVerticalScrollIndicator={false}
-        contentContainerStyle={{
-          flex: 1,
-          alignItems: 'stretch',
-          justifyContent: 'space-around'
-        }}
-      >
-        <View
+
+    //if admin account, add fields for resetting all users passwords
+    if (this.props.auth.user.Email__c === 'masteraccount@hands.org') {
+      return (
+        <KeyboardAwareScrollView
           style={{
-            height: 100,
-            width: 100,
-            borderRadius: 50,
-            backgroundColor: Colors.defaultColor.PAPER_COLOR,
-            alignItems: 'center',
-            alignSelf: 'center',
-            justifyContent: 'center'
+            backgroundColor: Colors.defaultColor.PAGE_BACKGROUND,
+            flex: 1
+          }}
+          resetScrollToCoords={{ x: 0, y: 0 }}
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{
+            flex: 1,
+            alignItems: 'stretch',
+            justifyContent: 'space-around'
           }}
         >
-          <Icon
-            name="user"
-            size={60}
-            color={Colors.defaultColor.PRIMARY_COLOR}
-          />
-        </View>
-        <View>
-          {this.props.auth && Name__c && (
-            <View
-              style={{
-                alignItems: 'center',
-                alignSelf: 'center',
-                justifyContent: 'center'
-              }}
-            >
-              <StyledText
-                style={{
-                  color: '#5a5b59',
-                  fontSize: 24,
-                  marginBottom: 4
-                }}
-              >{`Hi, ${Name__c}!`}</StyledText>
-              <StyledText
-                style={{
-                  color: '#5a5b59',
-                  fontSize: 24,
-                  marginBottom: 4
-                }}
-              >
-                {Email__c}
-              </StyledText>
-            </View>
-          )}
-        </View>
-        <View>
-          <StyledText
+          <View
             style={{
-              color: '#5a5b59',
-              margin: 20,
-              marginTop: 10,
-              marginBottom: 0
+              height: 100,
+              width: 100,
+              borderRadius: 50,
+              backgroundColor: Colors.defaultColor.PAPER_COLOR,
+              alignItems: 'center',
+              alignSelf: 'center',
+              justifyContent: 'center'
             }}
           >
-            CHANGE PASSWORD
-          </StyledText>
-          <StyledInput
-            secureTextEntry
-            clearTextOnFocus
-            returnKeyType="done"
+            <Icon
+              name="user"
+              size={60}
+              color={Colors.defaultColor.PRIMARY_COLOR}
+            />
+          </View>
+          <View>
+            <StyledText
+              style={{
+                color: '#5a5b59',
+                margin: 20,
+                marginTop: 10,
+                marginBottom: 0
+              }}
+            >
+              Please enter the email address of the user requesting the password
+              reset, and the password you would like their account reset to.
+            </StyledText>
+            <StyledText
+              style={{
+                color: '#5a5b59',
+                margin: 20,
+                marginTop: 10,
+                marginBottom: 0
+              }}
+            >
+              USER EMAIL ADDRESS
+            </StyledText>
+            <StyledInput
+              clearTextOnFocus
+              returnKeyType="done"
+              style={{
+                height: 42,
+                color: Colors.defaultColor.PRIMARY_COLOR,
+                backgroundColor: Colors.defaultColor.PAPER_COLOR,
+                borderColor: '#BFBFC0',
+                borderWidth: 0.3,
+                borderRadius: Colors.Input.BORDER.RADIUS
+              }}
+              placeholder="Enter user email address"
+              enablesReturnKeyAutomatically
+              inputRef={element => (this.passwordRef = element)}
+              onChangeText={value => this._handleOnChangeText('email', value)}
+              value={this.state.email}
+            />
+            <StyledText
+              style={{
+                color: '#5a5b59',
+                margin: 20,
+                marginTop: 10,
+                marginBottom: 0
+              }}
+            >
+              CHANGE PASSWORD
+            </StyledText>
+            <StyledInput
+              secureTextEntry
+              clearTextOnFocus
+              returnKeyType="done"
+              style={{
+                height: 42,
+                color: Colors.defaultColor.PRIMARY_COLOR,
+                backgroundColor: Colors.defaultColor.PAPER_COLOR,
+                borderColor: '#BFBFC0',
+                borderWidth: 0.3,
+                borderRadius: Colors.Input.BORDER.RADIUS
+              }}
+              placeholder="Enter new password *"
+              enablesReturnKeyAutomatically
+              inputRef={element => (this.passwordRef = element)}
+              onChangeText={value =>
+                this._handleOnChangeText('newPassword', value)
+              }
+              value={this.state.newPassword}
+            />
+            <StyledInput
+              secureTextEntry
+              clearTextOnFocus
+              returnKeyType="done"
+              style={{
+                height: 42,
+                color: Colors.defaultColor.PRIMARY_COLOR,
+                backgroundColor: Colors.defaultColor.PAPER_COLOR,
+                borderColor: '#BFBFC0',
+                borderWidth: 0.3,
+                borderRadius: Colors.Input.BORDER.RADIUS
+              }}
+              placeholder="Re-enter new password *"
+              enablesReturnKeyAutomatically
+              inputRef={element => (this.passwordRef = element)}
+              onChangeText={value =>
+                this._handleOnChangeText('rePassword', value)
+              }
+              value={this.state.rePassword}
+            />
+            <StyledButton2
+              buttonRef={ref => (this.styledButton2 = ref)}
+              label="Change password"
+              onPress={this.handlePaswordChange}
+              onSecondaryPress={() => this.styledButton2.reset()}
+            />
+          </View>
+          <View>
+            <StyledButton
+              style={{
+                height: 42,
+                backgroundColor: Colors.defaultColor.WARNING_COLOR
+              }}
+              textStyle={{ color: Colors.defaultColor.PAPER_COLOR }}
+              text="Log out"
+              onPress={() => this.props.logout()}
+            />
+          </View>
+        </KeyboardAwareScrollView>
+      );
+    } else {
+      return (
+        <KeyboardAwareScrollView
+          style={{
+            backgroundColor: Colors.defaultColor.PAGE_BACKGROUND,
+            flex: 1
+          }}
+          resetScrollToCoords={{ x: 0, y: 0 }}
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{
+            flex: 1,
+            alignItems: 'stretch',
+            justifyContent: 'space-around'
+          }}
+        >
+          <View
             style={{
-              height: 42,
-              color: Colors.defaultColor.PRIMARY_COLOR,
+              height: 100,
+              width: 100,
+              borderRadius: 50,
               backgroundColor: Colors.defaultColor.PAPER_COLOR,
-              borderColor: '#BFBFC0',
-              borderWidth: 0.3,
-              borderRadius: Colors.Input.BORDER.RADIUS
+              alignItems: 'center',
+              alignSelf: 'center',
+              justifyContent: 'center'
             }}
-            placeholder="Enter new password *"
-            enablesReturnKeyAutomatically
-            inputRef={element => (this.passwordRef = element)}
-            onChangeText={value =>
-              this._handleOnChangeText('newPassword', value)
-            }
-            value={this.state.newPassword}
-          />
-          <StyledInput
-            secureTextEntry
-            clearTextOnFocus
-            returnKeyType="done"
-            style={{
-              height: 42,
-              color: Colors.defaultColor.PRIMARY_COLOR,
-              backgroundColor: Colors.defaultColor.PAPER_COLOR,
-              borderColor: '#BFBFC0',
-              borderWidth: 0.3,
-              borderRadius: Colors.Input.BORDER.RADIUS
-            }}
-            placeholder="Re-enter new password *"
-            enablesReturnKeyAutomatically
-            inputRef={element => (this.passwordRef = element)}
-            onChangeText={value =>
-              this._handleOnChangeText('rePassword', value)
-            }
-            value={this.state.rePassword}
-          />
-          <StyledButton2
-            buttonRef={ref => (this.styledButton2 = ref)}
-            label="Change password"
-            onPress={this.handlePaswordChange}
-            onSecondaryPress={() => this.styledButton2.reset()}
-          />
-        </View>
-        <View>
-          <StyledButton
-            style={{
-              height: 42,
-              backgroundColor: Colors.defaultColor.WARNING_COLOR
-            }}
-            textStyle={{ color: Colors.defaultColor.PAPER_COLOR }}
-            text="Log out"
-            onPress={() => this.props.logout()}
-          />
-        </View>
-      </KeyboardAwareScrollView>
-    );
+          >
+            <Icon
+              name="user"
+              size={60}
+              color={Colors.defaultColor.PRIMARY_COLOR}
+            />
+          </View>
+          <View>
+            {this.props.auth && Name__c && (
+              <View
+                style={{
+                  alignItems: 'center',
+                  alignSelf: 'center',
+                  justifyContent: 'center'
+                }}
+              >
+                <StyledText
+                  style={{
+                    color: '#5a5b59',
+                    fontSize: 24,
+                    marginBottom: 4
+                  }}
+                >{`Hi, ${Name__c}!`}</StyledText>
+                <StyledText
+                  style={{
+                    color: '#5a5b59',
+                    fontSize: 24,
+                    marginBottom: 4
+                  }}
+                >
+                  {Email__c}
+                </StyledText>
+              </View>
+            )}
+          </View>
+          <View>
+            <StyledText
+              style={{
+                color: '#5a5b59',
+                margin: 20,
+                marginTop: 10,
+                marginBottom: 0
+              }}
+            >
+              CHANGE PASSWORD
+            </StyledText>
+            <StyledInput
+              secureTextEntry
+              clearTextOnFocus
+              returnKeyType="done"
+              style={{
+                height: 42,
+                color: Colors.defaultColor.PRIMARY_COLOR,
+                backgroundColor: Colors.defaultColor.PAPER_COLOR,
+                borderColor: '#BFBFC0',
+                borderWidth: 0.3,
+                borderRadius: Colors.Input.BORDER.RADIUS
+              }}
+              placeholder="Enter new password *"
+              enablesReturnKeyAutomatically
+              inputRef={element => (this.passwordRef = element)}
+              onChangeText={value =>
+                this._handleOnChangeText('newPassword', value)
+              }
+              value={this.state.newPassword}
+            />
+            <StyledInput
+              secureTextEntry
+              clearTextOnFocus
+              returnKeyType="done"
+              style={{
+                height: 42,
+                color: Colors.defaultColor.PRIMARY_COLOR,
+                backgroundColor: Colors.defaultColor.PAPER_COLOR,
+                borderColor: '#BFBFC0',
+                borderWidth: 0.3,
+                borderRadius: Colors.Input.BORDER.RADIUS
+              }}
+              placeholder="Re-enter new password *"
+              enablesReturnKeyAutomatically
+              inputRef={element => (this.passwordRef = element)}
+              onChangeText={value =>
+                this._handleOnChangeText('rePassword', value)
+              }
+              value={this.state.rePassword}
+            />
+            <StyledButton2
+              buttonRef={ref => (this.styledButton2 = ref)}
+              label="Change password"
+              onPress={this.handlePaswordChange}
+              onSecondaryPress={() => this.styledButton2.reset()}
+            />
+          </View>
+          <View>
+            <StyledButton
+              style={{
+                height: 42,
+                backgroundColor: Colors.defaultColor.WARNING_COLOR
+              }}
+              textStyle={{ color: Colors.defaultColor.PAPER_COLOR }}
+              text="Log out"
+              onPress={() => this.props.logout()}
+            />
+          </View>
+        </KeyboardAwareScrollView>
+      );
+    }
   }
 }


### PR DESCRIPTION
Adding functionality to allow admin to reset user passwords through the profile screen. Admin must login on admin account (username='masteraccount@hands.org' and password='admin'). 